### PR TITLE
Removed double "else" which broke the build.

### DIFF
--- a/procInfo/Signing.m
+++ b/procInfo/Signing.m
@@ -124,16 +124,6 @@ NSMutableDictionary* extractSigningInfo(pid_t pid, NSString* path, SecCSFlags fl
         }
     }
     
-    //invalid params
-    else
-    {
-        //set error
-        signingInfo[KEY_SIGNATURE_STATUS] = [NSNumber numberWithInt:errSecParam];
-        
-        //bail
-        goto bail;
-    }
-    
     //extract code signing id
     if(nil != [(__bridge NSDictionary*)signingDetails objectForKey:(__bridge NSString*)kSecCodeInfoIdentifier])
     {


### PR DESCRIPTION
Removed double "else" which broke the build. errSecParam isn't defined anywhere else in file so seemed right to remove it. Done with Xcode Version 10.0 (10A255)